### PR TITLE
Update taxonomy_select.sublime-snippet

### DIFF
--- a/snippets/fieldtypes/taxonomy_select.sublime-snippet
+++ b/snippets/fieldtypes/taxonomy_select.sublime-snippet
@@ -5,7 +5,7 @@
 	    'name'     => '${2:Taxonomy Select Field}', 
 	    'type'     => 'taxonomy_select', 
 	    'taxonomy' => '${3:category}' 
-	);
+	),
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>cmb:taxonomy_select</tabTrigger>


### PR DESCRIPTION
Snippet causes error
replaced ';' with ','